### PR TITLE
Implement Mobile Express Checkout (MEC)

### DIFF
--- a/lib/paypal-ec.js
+++ b/lib/paypal-ec.js
@@ -36,6 +36,7 @@ var API_METHODS = [
 var PayPalEC = function ( cred, opts ){
   this.nvpreq  = new NVPRequest( cred, opts );
   this.sandbox = opts ? opts.sandbox : false;
+  this.mobile_express_checkout = opts ? opts.mobile_express_checkout : false;
 };
 
 /**
@@ -61,7 +62,7 @@ PayPalEC.prototype.make_payment_url = function ( token ){
     host     : ( this.sandbox ) ? SANDBOX_URL : REGULAR_URL,
     pathname : '/cgi-bin/webscr',
     query    : {
-      cmd   : '_express-checkout',
+      cmd   : ( this.mobile_express_checkout ) ? '_express-checkout-mobile' : '_express-checkout',
       token : token
     }
   });


### PR DESCRIPTION
Add an option to enable mobile device support using MEC.

It's a simple option to return the PAYMENTURL with 'cmd' argument to
redirect url to '_express-checkout-mobile'.

Usage:

```
var cred = {
    username  : config.paypal.api_username,
    password  : config.paypal.api_password,
    signature : config.paypal.api_signature
};

var opts = {
    sandbox : true,
    mobile_express_checkout : true,
    version : '93'
};

var ec = new PayPalEC(cred, opts);

...
```

MEC details
https://developer.paypal.com/docs/classic/mobile/gs_MEC/
