### PR TITLE
Add support for 'GetTransactionDetails' method

### DIFF
--- a/lib/paypal-ec.js
+++ b/lib/paypal-ec.js
@@ -24,7 +24,8 @@ var API_METHODS = [
   'getExpressCheckoutDetails',
   'getRecurringPaymentsProfileDetails',
   'manageRecurringPaymentsProfileStatus',
-  'setExpressCheckout'
+  'setExpressCheckout',
+  'getTransactionDetails'
 ];
 
 /**
@@ -198,6 +199,15 @@ PayPalEC.prototype.create_billing_agreement = PayPalEC.prototype[ 'createBilling
  * @param {Function} callback Function to get called when done.
  */
 PayPalEC.prototype.do_reference_transaction = PayPalEC.prototype[ 'doReferenceTransaction' ];
+
+/**
+ * Make a `GetTransactionDetails` API call to PayPal.
+ * @public
+ * @this {PayPalEC}
+ * @param {Object} params Contain the TRANSACTIONID of the payment.
+ * @param {Function} callback Function to get called when done.
+*/
+PayPalEC.prototype.get_transaction_details = PayPalEC.prototype[ 'getTransactionDetails' ];
 
 module.exports = PayPalEC;
 


### PR DESCRIPTION
You may need this method if you want to check payment status, for example if transaction was held for PayPal review (https://developer.paypal.com/docs/classic/express-checkout/integration-guide/ECOtherAPIOps/)
