### PR TITLE
Added update_billing_agreement() method.

### DIFF
--- a/lib/paypal-ec.js
+++ b/lib/paypal-ec.js
@@ -14,6 +14,7 @@ var SANDBOX_URL = 'www.sandbox.paypal.com';
 var REGULAR_URL = 'www.paypal.com';
 var API_METHODS = [
   'createBillingAgreement',
+  'billAgreementUpdate',
   'createRecurringPaymentsProfile',
   'doAuthorization',
   'doCapture',
@@ -190,6 +191,15 @@ PayPalEC.prototype.manage_rpp_status = PayPalEC.prototype[ 'manageRecurringPayme
  * @param {Function} callback Function to get called when done.
  */
 PayPalEC.prototype.create_billing_agreement = PayPalEC.prototype[ 'createBillingAgreement' ];
+
+/**
+ * Make a `billAgreementUpdate` API call to PayPal.
+ * @public
+ * @this {PayPalEC}
+ * @param {Object} params Contain the billing agreement information to update.
+ * @param {Function} callback Function to get called when done.
+ */
+PayPalEC.prototype.update_billing_agreement = PayPalEC.prototype[ 'billAgreementUpdate' ];
 
 /**
  * Make a `doReferenceTransaction` API call to PayPal.


### PR DESCRIPTION
I added a method to update an existing billing agreement, as documented [here](https://developer.paypal.com/docs/classic/api/merchant/BAUpdate_API_Operation_NVP/). This change uses the `BillAgreementUpdate` NVP method. I am using this to implement cancelation of existing billing agreements.